### PR TITLE
Upgrade project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "lightgallery": "2.9.0",
     "negotiator": "^1.0.0",
-    "next": "^16.2.1",
+    "next": "16.1.3",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "pagefind": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -6,24 +6,24 @@
     "start": "next start"
   },
   "dependencies": {
-    "@formatjs/intl-localematcher": "0.8.0",
-    "@vercel/analytics": "^1.6.1",
-    "@vercel/speed-insights": "^1.3.1",
+    "@formatjs/intl-localematcher": "0.8.2",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "lightgallery": "2.9.0",
     "negotiator": "^1.0.0",
-    "next": "^16.1.3",
+    "next": "^16.2.1",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "pagefind": "^1.4.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "server-only": "0.0.1"
   },
   "devDependencies": {
     "@types/negotiator": "^0.6.4",
-    "@types/node": "^25.0.9",
-    "@types/react": "^19.2.8",
+    "@types/node": "^25.5.0",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^5.6.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.2"
+    "typescript": "^5.6.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
+    "types": ["node"],
     "lib": [
       "dom",
       "dom.iterable",
@@ -18,7 +19,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
-    "baseUrl": "./",
     "paths": {
       "@app/*": [
         "./app/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
-    "types": ["node"],
+    "target": "es5",
     "lib": [
       "dom",
       "dom.iterable",
@@ -19,6 +18,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
+    "baseUrl": "./",
     "paths": {
       "@app/*": [
         "./app/*"


### PR DESCRIPTION
## Summary
- Upgrade `@vercel/analytics` to v2.0.1 and `@vercel/speed-insights` to v2.0.0 (major)
- Upgrade `react` / `react-dom` to 19.2.4, `@formatjs/intl-localematcher` to 0.8.2
- Upgrade dev dependencies: `@types/node` to 25.5.0, `@types/react` to 19.2.14
- Pin `next` to 16.1.3 (Next.js 16.2 causes Turbopack SSR errors on Vercel)

## Notes
- TypeScript stays at 5.x — Nextra's twoslash requires `^5.5.0`, incompatible with TS 6.0
- Next.js pinned without `^` — 16.2.x has a Turbopack SSR bug causing `TypeError: is not a function` on Vercel serverless runtime. Unpin after upstream fix.

## Test plan
- [x] `pnpm build` passes locally
- [x] Verified on Vercel: pages render correctly, search works, no SSR errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)