### PR TITLE
Upgrade Next.js to 16.1.7 to fix security vulnerabilities

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "lightgallery": "2.9.0",
     "negotiator": "^1.0.0",
-    "next": "16.1.3",
+    "next": "~16.1.7",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "pagefind": "^1.4.0",


### PR DESCRIPTION
## Summary
- Upgrade Next.js from 16.1.3 to 16.1.7, fixing 8 Dependabot security alerts (1 high, 6 medium, 1 low)
- Use `~16.1.7` to allow patch updates while avoiding the 16.2 Turbopack SSR regression

## Security fixes
- **High**: HTTP request deserialization DoS via insecure RSC
- **Medium**: CSRF bypass, HTTP request smuggling, unbounded memory/disk growth, Image Optimizer DoS
- **Low**: Dev HMR websocket CSRF bypass

## Test plan
- [x] `pnpm build` passes locally
- [ ] Verify on Vercel: pages render correctly, search works, no SSR errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)