### PR TITLE
Upgrade Next.js to 16.2.3 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "lightgallery": "2.9.0",
     "negotiator": "^1.0.0",
-    "next": "~16.1.7",
+    "next": "~16.2.3",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "pagefind": "^1.4.0",


### PR DESCRIPTION
Fixes GHSA-q4gf-8mx6-v5v3 (CVE-2026-23869, CVSS 7.5): Server Components DoS via crafted HTTP requests to App Router Server Function endpoints. Build verified locally with no SSR regression.