### PR TITLE
SEO indexing improvements and Recently Published home section

### DIFF
--- a/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/app/[lang]/[[...mdxPath]]/page.tsx
@@ -6,6 +6,11 @@ import { i18n, type Locale } from '../../../i18n-config'
 
 const SITE = 'https://insights.kaho.io'
 
+// Top-level slugs that are not blog articles. They render as schema.org
+// WebPage rather than BlogPosting so search engines don't flag them for
+// missing Article-required fields like datePublished.
+const NON_ARTICLE_SLUGS = new Set(['say-hello', 'logs', 'japan-gallery'])
+
 export const generateStaticParams = generateStaticParamsFor('mdxPath')
 
 type PageProps = Readonly<{
@@ -56,25 +61,53 @@ const Page: FC<PageProps> = async (props) => {
 
   const slug = buildPath(params.mdxPath)
   const url = `${SITE}/${params.lang}${slug ? `/${slug}` : ''}`
+  const rootSlug = params.mdxPath?.[0] ?? ''
+  const isArticle = rootSlug !== '' && !NON_ARTICLE_SLUGS.has(rootSlug)
+  const published = (metadata as { publishedAt?: string } | undefined)?.publishedAt
 
-  // BlogPosting JSON-LD so Google can surface the article with rich
-  // metadata (title, description, language). Date fields are intentionally
-  // omitted until articles carry frontmatter dates.
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: metadata?.title ?? 'Insights',
-    description: metadata?.description ?? undefined,
-    inLanguage: hreflangFor(params.lang),
-    url,
-    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
-    image: `${SITE}/preview.png`,
-    publisher: {
-      '@type': 'Organization',
-      name: 'Insights',
-      logo: { '@type': 'ImageObject', url: `${SITE}/favicon.ico` },
+  const publisher = {
+    '@type': 'Organization',
+    name: 'Insights',
+    logo: {
+      '@type': 'ImageObject',
+      url: `${SITE}/preview.png`,
+      width: 1200,
+      height: 630,
     },
   }
+
+  const jsonLd = isArticle
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        headline: metadata?.title ?? 'Insights',
+        description: metadata?.description ?? undefined,
+        inLanguage: hreflangFor(params.lang),
+        url,
+        mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+        image: `${SITE}/preview.png`,
+        ...(published ? { datePublished: published, dateModified: published } : {}),
+        author: {
+          '@type': 'Person',
+          name: 'kaho',
+          url: SITE,
+        },
+        publisher,
+      }
+    : {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: metadata?.title ?? 'Insights',
+        description: metadata?.description ?? undefined,
+        inLanguage: hreflangFor(params.lang),
+        url,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Insights',
+          url: SITE,
+        },
+        publisher,
+      }
 
   return (
     <>

--- a/app/components/recent-posts.module.css
+++ b/app/components/recent-posts.module.css
@@ -5,8 +5,10 @@
 }
 
 .item {
-    padding: 1.5rem 0;
-    border-bottom: 1px solid rgba(127, 127, 127, 0.15);
+    padding: 1rem 0;
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
 }
 
 .item:first-child {
@@ -14,31 +16,60 @@
 }
 
 .item:last-child {
-    border-bottom: none;
     padding-bottom: 0;
 }
 
-.row {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    align-items: baseline;
-    flex-wrap: wrap;
+.content {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .title {
+    display: inline-block;
     font-weight: 600;
 }
 
+.coverLink {
+    flex: 0 0 auto;
+    line-height: 0;
+}
+
+.cover {
+    width: 192px;
+    height: 108px;
+    border-radius: 8px;
+    object-fit: cover;
+    background: rgba(127, 127, 127, 0.08);
+    display: block;
+}
+
+@media (max-width: 640px) {
+    .item {
+        gap: 1rem;
+    }
+
+    .cover {
+        width: 128px;
+        height: 72px;
+    }
+}
+
 .date {
+    display: block;
+    margin-top: 0.5rem;
     font-size: 0.85em;
-    opacity: 0.6;
+    opacity: 0.55;
     font-variant-numeric: tabular-nums;
-    white-space: nowrap;
 }
 
 .desc {
     margin: 0.5rem 0 0;
     font-size: 0.92em;
+    line-height: 1.6;
     opacity: 0.75;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
 }

--- a/app/components/recent-posts.module.css
+++ b/app/components/recent-posts.module.css
@@ -1,0 +1,44 @@
+.list {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0;
+}
+
+.item {
+    padding: 1.5rem 0;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.15);
+}
+
+.item:first-child {
+    padding-top: 0;
+}
+
+.item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: baseline;
+    flex-wrap: wrap;
+}
+
+.title {
+    font-weight: 600;
+}
+
+.date {
+    font-size: 0.85em;
+    opacity: 0.6;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.desc {
+    margin: 0.5rem 0 0;
+    font-size: 0.92em;
+    opacity: 0.75;
+}

--- a/app/components/recent-posts.tsx
+++ b/app/components/recent-posts.tsx
@@ -1,0 +1,100 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import Link from 'next/link'
+
+import styles from './recent-posts.module.css'
+
+interface Post {
+  href: string
+  title: string
+  description?: string
+  publishedAt: string
+}
+
+// Basenames excluded from the listing: nav-hidden pages (mirrors sitemap),
+// plus the listing pages themselves (say-hello, logs).
+const SKIP_BASENAMES = new Set([
+  'say-hello',
+  'logs',
+  'japan-gallery',
+  'series-outline',
+  'rag-r4',
+])
+
+function readField(src: string, key: string): string | undefined {
+  const re = new RegExp(
+    `${key}\\s*:\\s*(?:'((?:[^'\\\\]|\\\\.)*)'|"((?:[^"\\\\]|\\\\.)*)")`,
+  )
+  const m = src.match(re)
+  if (!m) return undefined
+  const raw = m[1] ?? m[2] ?? ''
+  return raw.replace(/\\'/g, "'").replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+}
+
+function hasNoindex(src: string): boolean {
+  return /robots\s*:\s*\{\s*index\s*:\s*false/.test(src)
+}
+
+async function collectPosts(locale: string): Promise<Post[]> {
+  const root = path.join(process.cwd(), 'content', locale)
+  const posts: Post[] = []
+
+  async function walk(dir: string, prefix: string[]) {
+    const entries = await readdir(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(full, [...prefix, entry.name])
+      } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+        const base = entry.name.replace(/\.mdx$/, '')
+        if (SKIP_BASENAMES.has(base)) continue
+        const src = await readFile(full, 'utf8')
+        if (hasNoindex(src)) continue
+        const publishedAt = readField(src, 'publishedAt')
+        if (!publishedAt) continue
+        // Prefer the H1 because it's what readers see at the top of the
+        // article (and what appears in nav). metadata.title is the SEO
+        // <title>, often a shortened variant without prefixes like "01：".
+        const h1 = src.match(/^#\s+(.+)$/m)
+        const title = h1?.[1]?.trim() ?? readField(src, 'title') ?? base
+        posts.push({
+          href: `/${locale}/${[...prefix, base].join('/')}`,
+          title,
+          description: readField(src, 'description'),
+          publishedAt,
+        })
+      }
+    }
+  }
+
+  await walk(root, [])
+  posts.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))
+  return posts
+}
+
+interface RecentPostsProps {
+  locale: string
+  limit?: number
+}
+
+export async function RecentPosts({ locale, limit = 6 }: RecentPostsProps) {
+  const posts = (await collectPosts(locale)).slice(0, limit)
+  return (
+    <ul className={styles.list}>
+      {posts.map((p) => (
+        <li key={p.href} className={styles.item}>
+          <div className={styles.row}>
+            <Link href={p.href} className={styles.title}>
+              {p.title}
+            </Link>
+            <time dateTime={p.publishedAt} className={styles.date}>
+              {p.publishedAt}
+            </time>
+          </div>
+          {p.description && <p className={styles.desc}>{p.description}</p>}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/components/recent-posts.tsx
+++ b/app/components/recent-posts.tsx
@@ -1,6 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 
+import Image from 'next/image'
 import Link from 'next/link'
 
 import styles from './recent-posts.module.css'
@@ -10,6 +11,7 @@ interface Post {
   title: string
   description?: string
   publishedAt: string
+  cover?: { src: string; alt: string }
 }
 
 // Basenames excluded from the listing: nav-hidden pages (mirrors sitemap),
@@ -34,6 +36,15 @@ function readField(src: string, key: string): string | undefined {
 
 function hasNoindex(src: string): boolean {
   return /robots\s*:\s*\{\s*index\s*:\s*false/.test(src)
+}
+
+// First Markdown image in the article body, e.g. `![alt](/path/foo.png)`.
+// We don't try to parse <img> JSX because every post in this codebase uses
+// Markdown image syntax for static covers.
+function readFirstImage(src: string): { src: string; alt: string } | undefined {
+  const m = src.match(/!\[([^\]]*)\]\(([^)\s]+)\)/)
+  if (!m || !m[2]) return undefined
+  return { src: m[2], alt: m[1] ?? '' }
 }
 
 async function collectPosts(locale: string): Promise<Post[]> {
@@ -63,6 +74,7 @@ async function collectPosts(locale: string): Promise<Post[]> {
           title,
           description: readField(src, 'description'),
           publishedAt,
+          cover: readFirstImage(src),
         })
       }
     }
@@ -84,15 +96,27 @@ export async function RecentPosts({ locale, limit = 6 }: RecentPostsProps) {
     <ul className={styles.list}>
       {posts.map((p) => (
         <li key={p.href} className={styles.item}>
-          <div className={styles.row}>
+          <div className={styles.content}>
             <Link href={p.href} className={styles.title}>
               {p.title}
             </Link>
+            {p.description && <p className={styles.desc}>{p.description}</p>}
             <time dateTime={p.publishedAt} className={styles.date}>
               {p.publishedAt}
             </time>
           </div>
-          {p.description && <p className={styles.desc}>{p.description}</p>}
+          {p.cover && (
+            <Link href={p.href} className={styles.coverLink} aria-hidden tabIndex={-1}>
+              <Image
+                src={p.cover.src}
+                alt={p.cover.alt}
+                width={192}
+                height={108}
+                className={styles.cover}
+                sizes="(max-width: 640px) 128px, 192px"
+              />
+            </Link>
+          )}
         </li>
       ))}
     </ul>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,17 +3,23 @@ import path from 'node:path'
 
 import type { MetadataRoute } from 'next'
 
-import { i18n } from '../i18n-config'
+import { i18n, type Locale } from '../i18n-config'
 
 const SITE = 'https://insights.kaho.io'
 
-// Pages whose route segment matches one of these are excluded from the sitemap
-// (hidden in `_meta.js` via `display: 'hidden'`).
-const HIDDEN_SEGMENTS = new Set(['japan-gallery'])
+// Route segments excluded from the sitemap. These pages are either hidden
+// from nav (`display: 'hidden'` in `_meta.js`) and not meant to be indexed,
+// or carry a `robots: { index: false }` frontmatter — listing them in the
+// sitemap would waste crawl budget.
+const HIDDEN_SEGMENTS = new Set(['japan-gallery', 'series-outline', 'rag-r4'])
 
-async function listMdxRoutes(locale: string): Promise<{ route: string; mtime: Date }[]> {
+function hreflangFor(locale: Locale): string {
+  return locale === 'zh' ? 'zh-CN' : 'en'
+}
+
+async function listMdxPaths(locale: Locale): Promise<Map<string, Date>> {
   const root = path.join(process.cwd(), 'content', locale)
-  const out: { route: string; mtime: Date }[] = []
+  const out = new Map<string, Date>()
 
   async function walk(dir: string, prefix: string) {
     const entries = await readdir(dir, { withFileTypes: true })
@@ -25,9 +31,9 @@ async function listMdxRoutes(locale: string): Promise<{ route: string; mtime: Da
         const base = entry.name.replace(/\.mdx$/, '')
         const segments = `${prefix}/${base}`.replace(/^\//, '').split('/')
         if (segments.some((s) => HIDDEN_SEGMENTS.has(s))) continue
-        const route = `/${locale}/${segments.join('/')}`
+        const relPath = segments.join('/')
         const { mtime } = await stat(full)
-        out.push({ route, mtime })
+        out.set(relPath, mtime)
       }
     }
   }
@@ -37,16 +43,33 @@ async function listMdxRoutes(locale: string): Promise<{ route: string; mtime: Da
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const entries: MetadataRoute.Sitemap = []
-
+  // Build per-locale maps so each entry can declare hreflang alternates for
+  // the language variants that actually exist on disk.
+  const byLocale = new Map<Locale, Map<string, Date>>()
   for (const locale of i18n.locales) {
-    const routes = await listMdxRoutes(locale)
-    for (const { route, mtime } of routes) {
+    byLocale.set(locale, await listMdxPaths(locale))
+  }
+  const defaultPaths = byLocale.get(i18n.defaultLocale)!
+
+  const entries: MetadataRoute.Sitemap = []
+  for (const locale of i18n.locales) {
+    const paths = byLocale.get(locale)!
+    for (const [relPath, mtime] of paths) {
+      const languages: Record<string, string> = {}
+      for (const alt of i18n.locales) {
+        if (byLocale.get(alt)!.has(relPath)) {
+          languages[hreflangFor(alt)] = `${SITE}/${alt}/${relPath}`
+        }
+      }
+      if (defaultPaths.has(relPath)) {
+        languages['x-default'] = `${SITE}/${i18n.defaultLocale}/${relPath}`
+      }
+
       entries.push({
-        url: `${SITE}${route}`,
+        url: `${SITE}/${locale}/${relPath}`,
         lastModified: mtime,
-        changeFrequency: 'monthly',
-        priority: route.endsWith('/say-hello') ? 1 : 0.7,
+        priority: relPath === 'say-hello' ? 1 : 0.7,
+        alternates: { languages },
       })
     }
   }

--- a/content/en/ai-era/llm-first-principles/series-outline.mdx
+++ b/content/en/ai-era/llm-first-principles/series-outline.mdx
@@ -1,7 +1,8 @@
 export const metadata = {
   title: 'Series Outline: Understanding LLMs from First Principles',
   description: 'A hidden writing memo for the series on understanding large language models from next-token prediction, covering the narrative arc and future topics.',
-  publishedAt: '2026-05-18'
+  publishedAt: '2026-05-18',
+  robots: { index: false, follow: true }
 }
 
 # Series Outline: Understanding LLMs from First Principles

--- a/content/en/ai-era/rag-r4.mdx
+++ b/content/en/ai-era/rag-r4.mdx
@@ -1,6 +1,7 @@
 export const metadata = {
   description: 'A walkthrough of the RAG-R4 (Read-Rewrite-Retrieve-Read) pipeline — currently a work in progress.',
-  publishedAt: '2024-03-15'
+  publishedAt: '2024-03-15',
+  robots: { index: false, follow: true }
 }
 
 # 🔗 Details of RAG R4 Link

--- a/content/en/logs.mdx
+++ b/content/en/logs.mdx
@@ -17,6 +17,7 @@ export const metadata = {
 * Published: [The Math Behind LLM Pricing 04: Cracking Open the KV Cache](../ai-era/llm-pricing-math/LLM-Learning-4.mdx)
 * Updated: [The Math Behind LLM Pricing 03: From Inference Latency to Inference Cost](../ai-era/llm-pricing-math/LLM-Learning-3.mdx) — added a Cost / Token interactive simulator
 * Published: [The Math Behind LLM Pricing 05: From One GPU to a Cluster — Parallelism and Interconnect](../ai-era/llm-pricing-math/LLM-Learning-5.mdx)
+* Updated: [👋 Hello, World!](./say-hello.mdx) — added a "Recently Published" section listing the latest posts
 
 ### 2026-01
 

--- a/content/en/say-hello.mdx
+++ b/content/en/say-hello.mdx
@@ -1,6 +1,6 @@
 export const metadata = {
   description: 'A product manager\'s notebook on AI, product design, and travel — built on Nextra + Vercel + GitHub. Methodology essays, tooling experiments, and journey logs.',
-  publishedAt: '2025-07-01'
+  publishedAt: '2026-05-21'
 }
 
 # 👋 Hello, World!
@@ -16,3 +16,7 @@ This is a casual blog about AI, product design, and travel.
 The solution is basically free (I bought a domain for a better experience), stable in service, and offers good access speed both domestically and internationally. It’s enjoyable to read on both PC and mobile. With git, multi-device synchronization and version management are possible. Writing on iPad is also a pleasure. Overall, I’ve found a solution I’m quite satisfied with.
 
 This site will be updated from time to time with insights from a product manager’s work, tool/product experience sharing, travel stories, and more. I hope it can be helpful or inspiring to you ❤️
+
+## Recently Published
+
+<RecentPosts locale="en" limit={6} />

--- a/content/en/say-hello.mdx
+++ b/content/en/say-hello.mdx
@@ -17,6 +17,6 @@ The solution is basically free (I bought a domain for a better experience), stab
 
 This site will be updated from time to time with insights from a product manager’s work, tool/product experience sharing, travel stories, and more. I hope it can be helpful or inspiring to you ❤️
 
-## Recently Published
+### 📅 Recently Published
 
 <RecentPosts locale="en" limit={6} />

--- a/content/zh/ai-era/llm-first-principles/series-outline.mdx
+++ b/content/zh/ai-era/llm-first-principles/series-outline.mdx
@@ -1,7 +1,8 @@
 export const metadata = {
   title: '系列大纲：用第一性原理理解大模型',
   description: '一份隐藏的系列写作备忘录，记录“从预测下一个 token 出发理解大模型”的主线、文章拆分、叙事结构和后续专题方向。',
-  publishedAt: '2026-05-18'
+  publishedAt: '2026-05-18',
+  robots: { index: false, follow: true }
 }
 
 # 系列大纲：用第一性原理理解大模型

--- a/content/zh/ai-era/rag-r4.mdx
+++ b/content/zh/ai-era/rag-r4.mdx
@@ -1,6 +1,7 @@
 export const metadata = {
   description: 'RAG-R4（Read-Rewrite-Retrieve-Read）链路的详细拆解，正在施工中。',
-  publishedAt: '2024-03-15'
+  publishedAt: '2024-03-15',
+  robots: { index: false, follow: true }
 }
 
 # 🔗 RAG-R4 链路详述

--- a/content/zh/logs.mdx
+++ b/content/zh/logs.mdx
@@ -17,6 +17,7 @@ export const metadata = {
 * 新增文档：[LLM 定价的数学原理 04：拆开 KV cache](../ai-era/llm-pricing-math/LLM-Learning-4.mdx)
 * 更新文档：[LLM 定价的数学原理 03：从推理耗时到推理成本](../ai-era/llm-pricing-math/LLM-Learning-3.mdx)，新增 Cost / Token 交互模拟器
 * 新增文档：[LLM 定价的数学原理 05：从单卡到集群——并行与互联](../ai-era/llm-pricing-math/LLM-Learning-5.mdx)
+* 更新文档：[👋 你好，世界！](./say-hello.mdx)，新增「最近发布」板块列出最新文章
 
 ### 2026-01
 

--- a/content/zh/say-hello.mdx
+++ b/content/zh/say-hello.mdx
@@ -1,6 +1,6 @@
 export const metadata = {
   description: '一个产品经理的 AI / 产品设计 / 旅行随笔站。基于 Nextra + Vercel + GitHub 搭建，记录工作中的方法论、工具体验，以及路上的折腾。',
-  publishedAt: '2025-07-01'
+  publishedAt: '2026-05-21'
 }
 
 # 👋 你好，世界！
@@ -16,3 +16,7 @@ export const metadata = {
 方案基本免费（为了体验购买了一个域名做绑定），服务稳定，在国内外都有不错的访问速度，PC/Mobile 上都可以愉快阅读，可以利用 git 实现多端同步和版本管理，可以利用 iPad 来写愉快写文，总体上找到了一个比较满意的解决方案。
 
 小站会不定期更新一些产品经理的工作心得、工具产品体验分享、旅游见闻等。希望能对你有帮助或启发 ❤️
+
+### 最近发布
+
+<RecentPosts locale="zh" limit={6} />

--- a/content/zh/say-hello.mdx
+++ b/content/zh/say-hello.mdx
@@ -17,6 +17,6 @@ export const metadata = {
 
 小站会不定期更新一些产品经理的工作心得、工具产品体验分享、旅游见闻等。希望能对你有帮助或启发 ❤️
 
-### 最近发布
+### 📅 近期发布
 
 <RecentPosts locale="zh" limit={6} />

--- a/mdx-components.js
+++ b/mdx-components.js
@@ -1,5 +1,6 @@
 import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs'
 import { ImageRow } from '@app/components/image-row'
+import { RecentPosts } from '@app/components/recent-posts'
 
 const themeComponents = getThemeComponents()
 const ThemeWrapper = themeComponents.wrapper
@@ -20,6 +21,7 @@ export function useMDXComponents(components) {
     ...themeComponents,
     wrapper: Wrapper,
     ImageRow,
+    RecentPosts,
     ...components
   }
 }


### PR DESCRIPTION
## Summary

- **JSON-LD**: articles now declare `datePublished` / `dateModified` / `author`; non-article pages (`say-hello`, `logs`, `japan-gallery`) render `WebPage` instead of `BlogPosting`; `publisher.logo` switched from `favicon.ico` to a real PNG so it passes Google's Rich Results Test
- **Sitemap**: every URL now carries `xhtml:link rel="alternate" hreflang` for `en` / `zh-CN` / `x-default`; dropped Google-ignored `changefreq`; hidden memo pages (`series-outline`, `rag-r4`) excluded from sitemap and marked `robots: { index: false, follow: true }` so they stop wasting crawl budget
- **Recently Published**: new `<RecentPosts>` server component scans `content/{locale}/**/*.mdx`, drops listing/hidden pages and `noindex` posts, sorts by `publishedAt` desc, and renders the latest 6 on `say-hello` with title + 3-line clamped description + date + 16:9 cover (first Markdown image in the post, served through `next/image` for AVIF/WebP + srcset)

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `curl https://insights.kaho.io/sitemap.xml` returns 38 URLs, each with `xhtml:link` hreflang triples, no `changefreq`, no `series-outline` / `rag-r4` / `japan-gallery`
- [ ] `view-source:/en/ai-era/intent` JSON-LD contains `datePublished`, `dateModified`, `author`
- [ ] `view-source:/en/ai-era/rag-r4` and `view-source:/en/ai-era/llm-first-principles/series-outline` show `<meta name="robots" content="noindex, follow">`
- [ ] `/en/say-hello` and `/zh/say-hello` show 6 latest posts with covers where available; cards without a cover collapse cleanly to text-only
- [ ] DevTools Network → cover image requests hit `/_next/image?url=...&w=...`; mobile viewport (≤640px) requests narrower variants
- [ ] Clicking a card title or cover triggers Next client-side navigation (no full page reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)