### PR TITLE
Auto-hide sidebar on scroll, hide navbar on scroll-down

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -4,6 +4,8 @@ import { getPageMap } from 'nextra/page-map'
 import { getDictionary, getDirection } from '../../get-dictionary'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { NavbarAutoHide } from '../components/navbar-auto-hide'
+import { SidebarAutoHide } from '../components/sidebar-auto-hide'
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import type { Locale } from '../../i18n-config'
@@ -97,6 +99,8 @@ export default async function RootLayout({ children, params }: LayoutProps) {
           }}
         >
           {children}
+          <NavbarAutoHide />
+          <SidebarAutoHide />
           <Analytics />
           <SpeedInsights />
         </Layout>

--- a/app/components/navbar-auto-hide.tsx
+++ b/app/components/navbar-auto-hide.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect } from 'react'
+
+const TOP_REVEAL_ZONE = 64
+const SCROLL_DELTA = 4
+
+export function NavbarAutoHide() {
+  useEffect(() => {
+    const root = document.documentElement
+    let lastY = window.scrollY
+    let ticking = false
+
+    const apply = () => {
+      ticking = false
+      const y = window.scrollY
+      const delta = y - lastY
+
+      if (Math.abs(delta) < SCROLL_DELTA) return
+
+      if (y <= TOP_REVEAL_ZONE) {
+        root.removeAttribute('data-navbar-hidden')
+      } else if (delta > 0) {
+        root.setAttribute('data-navbar-hidden', 'true')
+      } else {
+        root.removeAttribute('data-navbar-hidden')
+      }
+
+      lastY = y
+    }
+
+    const onScroll = () => {
+      if (ticking) return
+      ticking = true
+      requestAnimationFrame(apply)
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      root.removeAttribute('data-navbar-hidden')
+    }
+  }, [])
+
+  return null
+}

--- a/app/components/sidebar-auto-hide.tsx
+++ b/app/components/sidebar-auto-hide.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect } from 'react'
+
+const SCROLL_THRESHOLD = 64
+
+export function SidebarAutoHide() {
+  useEffect(() => {
+    const root = document.documentElement
+    let ticking = false
+
+    const apply = () => {
+      ticking = false
+      if (window.scrollY > SCROLL_THRESHOLD) {
+        root.setAttribute('data-sidebar-hidden', 'true')
+      } else {
+        root.removeAttribute('data-sidebar-hidden')
+      }
+    }
+
+    const onScroll = () => {
+      if (ticking) return
+      ticking = true
+      requestAnimationFrame(apply)
+    }
+
+    apply()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      root.removeAttribute('data-sidebar-hidden')
+    }
+  }, [])
+
+  return <div className="nextra-sidebar-hotzone" aria-hidden />
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -90,3 +90,30 @@ article h2 {
 html[data-navbar-hidden] .nextra-navbar {
   transform: translateY(-100%);
 }
+
+/* Hide the sidebar's scrollbar when idle, fade it in on hover. macOS uses
+   overlay scrollbars natively, but Windows Chrome shows a permanent thin
+   scrollbar inside .nextra-scrollbar — this gives a consistent feel across
+   platforms. `scrollbar-gutter: stable` is left intact upstream, so the
+   layout doesn't shift when the thumb appears. */
+@media (hover: hover) and (pointer: fine) {
+  .nextra-sidebar .nextra-scrollbar {
+    scrollbar-color: transparent transparent;
+  }
+  .nextra-sidebar:hover .nextra-scrollbar,
+  .nextra-sidebar .nextra-scrollbar:focus-within {
+    scrollbar-color: rgba(128, 128, 128, 0.45) transparent;
+  }
+  .nextra-sidebar .nextra-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+  .nextra-sidebar .nextra-scrollbar::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+  }
+  .nextra-sidebar:hover .nextra-scrollbar::-webkit-scrollbar-thumb,
+  .nextra-sidebar .nextra-scrollbar:focus-within::-webkit-scrollbar-thumb {
+    background-color: rgba(128, 128, 128, 0.45);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,3 +41,52 @@ article h2 {
   overflow-x: auto;
   overflow-y: hidden;
 }
+
+/* Auto-hide left sidebar on desktop once the reader scrolls past the fold.
+   The sidebar slides left, leaving an 8px sliver as the only visible cue.
+   A separate viewport-fixed hot zone (.nextra-sidebar-hotzone) extends the
+   effective hover area to 32px without altering the silhouette. The hot
+   zone is NOT a child of the sidebar, so it does not travel with the
+   sidebar's transform — that decoupling is what prevents the hover/unhover
+   feedback loop that would otherwise cause jitter at the edge.
+
+   Important: do not set `transition: transform ...` on .nextra-sidebar — the
+   shorthand would override Nextra's own `transition-all`, which makes the
+   w-64↔w-20 width change instantaneous. Nextra's Collapse component then
+   measures child.clientWidth at the wrong moment and locks the menu to the
+   collapsed width. Leaving transition-all in place keeps both transform and
+   width animating, and Collapse measures correctly. */
+.nextra-sidebar-hotzone {
+  display: none;
+}
+@media (min-width: 768px) {
+  html[data-sidebar-hidden] .nextra-sidebar {
+    transform: translateX(calc(-100% + 8px));
+    z-index: 20;
+  }
+  html[data-sidebar-hidden] .nextra-sidebar-hotzone {
+    display: block;
+    position: fixed;
+    left: 0;
+    top: var(--nextra-navbar-height);
+    width: 32px;
+    height: calc(100dvh - var(--nextra-navbar-height));
+    z-index: 21;
+  }
+  html[data-sidebar-hidden] .nextra-sidebar:hover,
+  html[data-sidebar-hidden]:has(.nextra-sidebar-hotzone:hover) .nextra-sidebar {
+    transform: translateX(0);
+  }
+}
+
+/* Direction-aware navbar: hides on scroll-down, reveals on scroll-up, and
+   always reveals near the top. State is driven by data-navbar-hidden on
+   <html>. Translating the sticky header off-screen keeps the layout stable
+   without remeasuring scroll offsets. */
+.nextra-navbar {
+  transition: transform 0.25s ease;
+  will-change: transform;
+}
+html[data-navbar-hidden] .nextra-navbar {
+  transform: translateY(-100%);
+}


### PR DESCRIPTION
Sidebar slides left past a 64px scroll threshold, leaving an 8px visual sliver; a viewport-fixed 32px hot zone (decoupled from the sidebar's transform) brings it back on hover without edge jitter. Navbar hides on scroll-down and reveals on scroll-up or near the top.