### PR TITLE
Keep post 01 in place in Recent; hide the WIP draft from it

### DIFF
--- a/content/en/ai-era/llm-first-principles/01-next-token-prediction.mdx
+++ b/content/en/ai-era/llm-first-principles/01-next-token-prediction.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 export const metadata = {
   title: 'The First Principle of LLMs: Predicting the Next Token',
   description: 'A beginner-friendly explanation of why large language models are not knowledge databases, but probabilistic systems that compress patterns in language by predicting the next token.',
-  publishedAt: '2026-06-05'
+  publishedAt: '2026-05-18'
 }
 
 # 01: The First Principle of LLMs

--- a/content/zh/ai-era/llm-first-principles/01-next-token-prediction.mdx
+++ b/content/zh/ai-era/llm-first-principles/01-next-token-prediction.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 export const metadata = {
   title: '大模型的第一性原理：预测下一个 token',
   description: '从预测下一个 token 出发，用零基础也能理解的方式解释大模型为什么不是知识库，也不只是高级输入法，而是通过压缩语言分布间接学习世界结构的概率系统。',
-  publishedAt: '2026-06-05'
+  publishedAt: '2026-05-18'
 }
 
 # 01：LLM 的第一性原理

--- a/content/zh/ten-years-review.mdx
+++ b/content/zh/ten-years-review.mdx
@@ -1,7 +1,8 @@
 export const metadata = {
   title: '十年回顾',
   description: '关于简单、自由、利他与长期主义的产品思考笔记，从人群、问题、价值到定位与成本逐步梳理（持续施工中）。',
-  publishedAt: '2026-06-05'
+  publishedAt: '2026-06-05',
+  robots: { index: false }
 }
 
 # 施工中


### PR DESCRIPTION
- Revert post 01's publishedAt to its original 2026-05-18 (EN + ZH). Its first-principles section was expanded last commit, but the display date shouldn't jump forward, so it stays in its original slot in the "Recent" list instead of leaping to the top.
- Add robots: { index: false } to ten-years-review.mdx so the RecentPosts noindex filter drops the work-in-progress draft (and search engines skip it too), keeping the unfinished page out of the listing.